### PR TITLE
商品表示一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all
+    @items = Item.all.order( "created_at DESC" )
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,65 +120,55 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+    <% if @items.present? %>
+    <% @items.each do |item|%>
+       <li class='list'>
+         <%= link_to "#" do %>
+         <div class='item-img-content'>
+           <%= image_tag item.image, class: "item-img" %>
+           <div class='sold-out'>
+             <span>Sold Out!!</span>
+           </div>
+         </div>
+         <div class='item-info'>
+           <h3 class='item-name'>
+             <%= item.name %>
+           </h3>
+           <div class='item-price'>
+             <span><%= item.price %>円<br><%= item.fee.name %></span>
+             <div class='star-btn'>
+               <span class='star-count'>0</span>
+             </div>
+           </div>
+         </div>
+         <% end %>
+       </li>
+       <% end %>
+       <% else %>
+       <li class='list'>
+         <%= link_to '#' do %>
+         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+         <div class='item-info'>
+           <h3 class='item-name'>
+             商品を出品してね！
+           </h3>
+           <div class='item-price'>
+             <span>99999999円<br>(税込み)</span>
+             <div class='star-btn'>
+               <%= image_tag "star.png", class:"star-icon" %>
+               <span class='star-count'>0</span>
+             </div>
+           </div>
+         </div>
+         <% end %>
+       </li>
+       <% end %>
+     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
 # What
 出品商品の表示一覧及びダミーまたは商品情報の表示、ログイン有無に関わらず閲覧可能の機能実装
# Why
 フリマアプリに必要な商品表示一覧機能を実装するため


# プルリクエストへ記載するgyazo
 [https://gyazo.com/67a3568d044e20f0edaa6d54dee71401][商品のデータがない場合は、ダミー商品が表示されている動画]
 [https://gyazo.com/08af79451d82e11b898e3db1f7797e2c][商品のデータがある場合は、商品が一覧で表示されている動画]